### PR TITLE
Month header is now localizable. Localization is respected, throughout the calendar.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { Example1 } from "./examples/Example1";
 import { Example2 } from "./examples/Example2";
 import { Example3 } from "./examples/Example3";
+import { Example4 } from "./examples/Example4";
 import './App.css';
 
 type State = {
@@ -15,6 +16,7 @@ const EXAMPLES = {
   Example1,
   Example2,
   Example3,
+  Example4,
 };
 
 class App extends Component<{}, State> {
@@ -30,7 +32,7 @@ class App extends Component<{}, State> {
 
   render() {
     return (
-      <div style={{ display: "flex", flexDirection: "row", width: "100%", height: "100%", }}>
+      <div style={{ display: "flex", flexDirection: "row", width: "100%", height: "100%" }}>
         <div
           style={{ 
             display: "flex", 
@@ -62,7 +64,7 @@ class App extends Component<{}, State> {
           }
         </form>
         </div>
-        <div style={{ display: "flex", width: "100%", height: "100%", }} className="App">
+        <div style={{ display: "flex", width: "100%", height: "100%", justifyContent: "center" }} className="App">
           {
             this.renderExample(EXAMPLES[this.state.selectedExample])
           }

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 
 import { Example1 } from "./examples/Example1";
 import { Example2 } from "./examples/Example2";
+import { Example3 } from "./examples/Example3";
 import './App.css';
 
 type State = {
@@ -13,6 +14,7 @@ type State = {
 const EXAMPLES = {
   Example1,
   Example2,
+  Example3,
 };
 
 class App extends Component<{}, State> {
@@ -44,15 +46,17 @@ class App extends Component<{}, State> {
         <form style={{ display: "flex", flexDirection: "column" }}>
           {
             Object.keys(EXAMPLES).map(key => (
-              <div style={{ display: "flex", flexDirection: "row" }} key={key}>
-                <input
-                  type="radio"
-                  name={key}
-                  value={key}
-                  checked={key === this.state.selectedExample}
-                  onClick={() => this.setState({ selectedExample: key })}
-                />
-                <label>{key}</label>
+              <div style={{ display: "flex", flexDirection: "column" }} key={key}>
+                <label style={{ display: "flex", flexDirection: "row" }}>
+                  <input
+                    type="radio"
+                    name={key}
+                    value={key}
+                    checked={key === this.state.selectedExample}
+                    onClick={() => this.setState({ selectedExample: key })}
+                  />
+                  {key}
+                </label>
               </div>
             ))
           }

--- a/src/App.js
+++ b/src/App.js
@@ -2,70 +2,67 @@
 
 import React, { Component } from 'react';
 
-import { Calendar } from './calendar/Calendar';
+import { Example1 } from "./examples/Example1";
+import { Example2 } from "./examples/Example2";
 import './App.css';
 
 type State = {
-  year: number,
-  month: number,
-  selectedCellIDs: Array<string>
+  selectedExample: string,
+}
+
+const EXAMPLES = {
+  Example1,
+  Example2,
 };
 
-type Props = {};
-
-class App extends Component<Props, State> {
-  constructor(props: Props) {
+class App extends Component<{}, State> {
+  constructor(props: {}) {
     super(props);
-    const date = new Date();
-    this.state = { year: date.getFullYear(), month: date.getMonth() + 1, selectedCellIDs: []};
+    this.state = { selectedExample: Object.keys(EXAMPLES)[0] };
   }
 
-  renderDay = (date: Date, cellID: string, selectedYear: number, selectedMonth: number) => {
-    const dayNumber = date.getDate();
-    const dayText = dayNumber === 1 ? `${date.toLocaleDateString("en-us", {month: 'short'})} ${dayNumber}` : dayNumber;
-    const selectedMonthStartDate = new Date(selectedYear, selectedMonth - 1, 1); // first day of month.
-    const selectedMonthEndDate = new Date(selectedYear, selectedMonth, 0); // last day of month.
-    const dayIsInSelectedMonth = date >= selectedMonthStartDate && date <= selectedMonthEndDate;
-    const isToday = new Date().toDateString() === date.toDateString();
-    let color = `grey`;
-    let fontWeight = `normal`;
-    if (isToday) {
-      color = `blue`;
-      fontWeight = `bold`;
-    } else if (dayIsInSelectedMonth) {
-      color = `black`;
-    }
-    const backgroundColor = this.state.selectedCellIDs.indexOf(cellID) !== -1 ? `yellow` : `white`;
-    return (
-      <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart`, backgroundColor }} className="calendar-day">
-        <div style={{ display: 'flex', flex: 1, margin: 5, color, fontWeight }}>
-          {dayText}
-        </div>
-      </div>
-    );
-  }
-
-  onDayPress = (date: Date, cellID: string) => {
-    if (this.state.selectedCellIDs.indexOf(cellID) !== -1) {
-      this.setState({ selectedCellIDs: this.state.selectedCellIDs.filter(cID => cID !== cellID) });
-    } else {
-      this.setState({ selectedCellIDs: [...this.state.selectedCellIDs, cellID]});
-    }
+  renderExample(exampleComponent: any) {
+    const ExampleComponent = exampleComponent;
+    return <ExampleComponent />;
   }
 
   render() {
     return (
-      <div style={{ display: "flex", width: "100%", height: "100%", }} className="App">
-        <Calendar
-          locale="en-ca"
-          year={this.state.year}
-          month={this.state.month}
-          renderDay={(date, cellID) => this.renderDay(date, cellID, this.state.year, this.state.month)}
-          borderOptions={{ width: 1, color: "black" }}
-          onDayPress={this.onDayPress}
-          onNextMonthClicked={(year, month) => this.setState({ year, month })}
-          onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
-        />
+      <div style={{ display: "flex", flexDirection: "row", width: "100%", height: "100%", }}>
+        <div
+          style={{ 
+            display: "flex", 
+            flexDirection: "column", 
+            borderStyle: "solid",
+            borderColor: "black",
+            borderWidth: 0,
+            borderRightWidth: 2,
+            padding: 10,
+            paddingRight: 20,
+          }}
+        >
+        <form style={{ display: "flex", flexDirection: "column" }}>
+          {
+            Object.keys(EXAMPLES).map(key => (
+              <div style={{ display: "flex", flexDirection: "row" }} key={key}>
+                <input
+                  type="radio"
+                  name={key}
+                  value={key}
+                  checked={key === this.state.selectedExample}
+                  onClick={() => this.setState({ selectedExample: key })}
+                />
+                <label>{key}</label>
+              </div>
+            ))
+          }
+        </form>
+        </div>
+        <div style={{ display: "flex", width: "100%", height: "100%", }} className="App">
+          {
+            this.renderExample(EXAMPLES[this.state.selectedExample])
+          }
+        </div>
       </div>
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -57,9 +57,11 @@ class App extends Component<Props, State> {
     return (
       <div style={{ display: "flex", width: "100%", height: "100%", }} className="App">
         <Calendar
+          locale="en-ca"
           year={this.state.year}
           month={this.state.month}
           renderDay={(date, cellID) => this.renderDay(date, cellID, this.state.year, this.state.month)}
+          borderOptions={{ width: 1, color: "black" }}
           onDayPress={this.onDayPress}
           onNextMonthClicked={(year, month) => this.setState({ year, month })}
           onPreviousMonthClicked={(year, month) => this.setState({ year, month })}

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -4,8 +4,6 @@ import React from 'react';
 import type { Node } from 'react';
 
 import { Month } from './components/Month';
-import { Pager } from './components/Pager';
-import { nextMonth, previousMonth } from './util/date';
 import type { BorderOptions } from "./types";
 
 type CalendarProps = {
@@ -13,29 +11,17 @@ type CalendarProps = {
   month: number,
   locale: string,
   renderDay: (date: Date, cellID: string) => Node,
+  renderHeading?: () => Node,
   borderOptions?: BorderOptions,
   // Since you can render the day as you please, onDayPress is a convenience method. You can implement your own 
   // onPress logic within you renderDay method, if you'd prefer.
   onDayPress?: (date: Date, cellID: string) => void,
-  onNextMonthClicked: (year: number, month: number) => void,
-  onPreviousMonthClicked: (year: number, month: number) => void,
 };
 
 export const Calendar = (props: CalendarProps) => {
-  const firstOfMonth = new Date(props.year, props.month-1, 1); // Convert from 1-indexed to 0-indexed.
   return (
     <div style={{ display: "flex", flex: 1, flexDirection: "column" }}>
-      <Pager 
-        title={firstOfMonth.toLocaleDateString(props.locale, { month: "long", year: "numeric" })}
-        onNextMonthClicked={() => {
-          const { year, month } = nextMonth(props.year, props.month);
-          props.onNextMonthClicked(year, month);
-        }}
-        onPreviousMonthClicked={() => {
-          const { year, month } = previousMonth(props.year, props.month);
-          props.onPreviousMonthClicked(year, month);
-        }}
-      />
+      { props.renderHeading && props.renderHeading() }
       <Month
         locale={props.locale}
         year={props.year}

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -6,7 +6,7 @@ import type { Node } from 'react';
 import { Month } from './components/Month';
 import type { BorderOptions } from "./types";
 
-type CalendarProps = {
+type CalendarProps = {|
   year: number,
   month: number,
   locale: string,
@@ -16,7 +16,7 @@ type CalendarProps = {
   // Since you can render the day as you please, onDayPress is a convenience method. You can implement your own 
   // onPress logic within you renderDay method, if you'd prefer.
   onDayPress?: (date: Date, cellID: string) => void,
-};
+|};
 
 export const Calendar = (props: CalendarProps) => {
   return (

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -6,14 +6,17 @@ import type { Node } from 'react';
 import { Month } from './components/Month';
 import { Pager } from './components/Pager';
 import { nextMonth, previousMonth } from './util/date';
+import type { BorderOptions } from "./types";
 
 type CalendarProps = {
   year: number,
   month: number,
+  locale: string,
   renderDay: (date: Date, cellID: string) => Node,
+  borderOptions?: BorderOptions,
   // Since you can render the day as you please, onDayPress is a convenience method. You can implement your own 
   // onPress logic within you renderDay method, if you'd prefer.
-  onDayPress: (date: Date, cellID: string) => void,
+  onDayPress?: (date: Date, cellID: string) => void,
   onNextMonthClicked: (year: number, month: number) => void,
   onPreviousMonthClicked: (year: number, month: number) => void,
 };
@@ -23,7 +26,7 @@ export const Calendar = (props: CalendarProps) => {
   return (
     <div style={{ display: "flex", flex: 1, flexDirection: "column" }}>
       <Pager 
-        title={firstOfMonth.toLocaleDateString("en-us", { month: "long", year: "numeric" })}
+        title={firstOfMonth.toLocaleDateString(props.locale, { month: "long", year: "numeric" })}
         onNextMonthClicked={() => {
           const { year, month } = nextMonth(props.year, props.month);
           props.onNextMonthClicked(year, month);
@@ -34,10 +37,12 @@ export const Calendar = (props: CalendarProps) => {
         }}
       />
       <Month
+        locale={props.locale}
         year={props.year}
         month={props.month}
         renderDay={props.renderDay}
         onDayPress={props.onDayPress}
+        borderOptions={props.borderOptions}
       />
     </div>
   );

--- a/src/calendar/components/Month.css
+++ b/src/calendar/components/Month.css
@@ -14,3 +14,13 @@
 .Month-day {
   flex: 1;
 }
+
+.Month-week-header {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+}
+
+.Month-week-header-weekday {
+  flex: 1;
+}

--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -32,7 +32,13 @@ const dateOfCalendarWeekAndWeekdayIndex = (year: number, month: number, dayOffse
 }
 
 const borderStyle = (dayIndex: number, weekIndex: number, lastWeekIndex: number, borderOptions: BorderOptions) => {
-  const { width: borderWidth, color: borderColor } = borderOptions;
+  let borderWidth, borderColor;
+  if (borderOptions === "no-border") {
+    borderWidth = 0;
+    borderColor = "black";
+  } else {
+    ({ width: borderWidth, color: borderColor } = borderOptions);
+  }
   const borderTop = borderWidth;
   const borderLeft = borderWidth;
   const borderRight = dayIndex === 6 ? borderWidth : 0;
@@ -82,7 +88,7 @@ export const Month = (props: MonthProps) => {
                       weekdayIndex,
                       weekOfMonthIndex, 
                       weekPerMonthRange.length - 1, 
-                      props.borderOptions || defaultBorderOptions
+                      props.borderOptions || defaultBorderOptions,
                     )
                   }}
                   key={weekdayIndex} 

--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -3,17 +3,25 @@
 import React from 'react';
 import type { Node } from 'react';
 
-import { calendarWeeksInMonth, firstWeekdayInMonth } from "../util/date";
+import { calendarWeeksInMonth, firstWeekdayInMonth, weekOrderedByGivenFirstWeekday } from "../util/date";
 import "./Month.css";
+import type { BorderOptions, Weekday } from "../types";
+
 
 type MonthProps = {
+  locale: string,
   year: number,
   month: number,
   renderDay: (date: Date, cellID: string) => Node,
-  onDayPress: (date: Date, cellID: string) => void,
+  onDayPress?: (date: Date, cellID: string) => void,
+  borderOptions?: BorderOptions,
 };
 
 const daysPerWeek = 7;
+const defaultBorderOptions: BorderOptions = {
+  width: 1,
+  color: "black",
+};
 
 const dayOfMonth = (weekOfMonthIndex: number, weekdayIndex: number, weekdayOfTheFirst: number) => {
   return (weekOfMonthIndex * 7) + weekdayIndex - weekdayOfTheFirst + 1;
@@ -23,53 +31,72 @@ const dateOfCalendarWeekAndWeekdayIndex = (year: number, month: number, dayOffse
   return new Date(year, month-1, dayOffset);
 }
 
-const borderStyle = (dayIndex, weekIndex, lastWeekIndex) => {
-  const borderTop = 1;
-  const borderLeft = 1;
-  const borderRight = dayIndex === 6 ? 1 : 0;
-  const borderBottom = weekIndex === lastWeekIndex ? 1 : 0
+const borderStyle = (dayIndex: number, weekIndex: number, lastWeekIndex: number, borderOptions: BorderOptions) => {
+  const { width: borderWidth, color: borderColor } = borderOptions;
+  const borderTop = borderWidth;
+  const borderLeft = borderWidth;
+  const borderRight = dayIndex === 6 ? borderWidth : 0;
+  const borderBottom = weekIndex === lastWeekIndex ? borderWidth : 0
   return {
     borderTop,
     borderRight,
     borderBottom,
     borderLeft,
+    borderColor,
     borderStyle: "solid",
-    borderColor: "black",
   }
+}
+
+const Header = (props: { locale: string, firstWeekday: Weekday }) => {
+  return (
+    <div className="Month-week-header">
+      {weekOrderedByGivenFirstWeekday(props.locale, props.firstWeekday).map(weekdayName =>
+        <div className="Month-week-header-weekday" key={weekdayName}>{weekdayName}</div>
+      )}
+    </div>
+  );
 }
 
 export const Month = (props: MonthProps) => {
   const weekdayOfTheFirst = firstWeekdayInMonth(props.year, props.month);
-  const weekPerMonthRange = [...Array(calendarWeeksInMonth(props.year, props.month, "Sunday")).keys()];
+  const weekPerMonthRange = [...Array(calendarWeeksInMonth(props.year, props.month, 0)).keys()];
   const dayPerWeekRange = [...Array(daysPerWeek).keys()];
   return (
     <div className="Month-month">
-    {
-      weekPerMonthRange.map(weekOfMonthIndex => (
-        <div key={weekOfMonthIndex} className="Month-week">
-        {
-          dayPerWeekRange.map(weekdayIndex => {
-            const cellDate = dateOfCalendarWeekAndWeekdayIndex(
-              props.year,
-              props.month,
-              dayOfMonth(weekOfMonthIndex, weekdayIndex, weekdayOfTheFirst)
-            );
-            const cellID = `${weekOfMonthIndex}-${weekdayIndex}`;
-            return (
-              <div 
-                style={{ ...borderStyle(weekdayIndex, weekOfMonthIndex, weekPerMonthRange.length - 1)}} 
-                key={weekdayIndex} 
-                className="Month-day Month-day-{cellID}"
-                onClick={() => props.onDayPress(cellDate, cellID)}
-              >
-                {props.renderDay(cellDate, cellID)}
-              </div>
-            );
-          })
-        }
-        </div>
-      ))
-    }
+      <Header firstWeekday={0} locale={props.locale} />
+      {
+        weekPerMonthRange.map(weekOfMonthIndex => (
+          <div key={weekOfMonthIndex} className="Month-week">
+          {
+            dayPerWeekRange.map(weekdayIndex => {
+              const cellDate = dateOfCalendarWeekAndWeekdayIndex(
+                props.year,
+                props.month,
+                dayOfMonth(weekOfMonthIndex, weekdayIndex, weekdayOfTheFirst)
+              );
+              const cellID = `${weekOfMonthIndex}-${weekdayIndex}`;
+              return (
+                <div 
+                  style={{ 
+                    ...borderStyle(
+                      weekdayIndex,
+                      weekOfMonthIndex, 
+                      weekPerMonthRange.length - 1, 
+                      props.borderOptions || defaultBorderOptions
+                    )
+                  }}
+                  key={weekdayIndex} 
+                  className="Month-day Month-day-{cellID}"
+                  onClick={() => props.onDayPress != null && props.onDayPress(cellDate, cellID)}
+                >
+                  {props.renderDay(cellDate, cellID)}
+                </div>
+              );
+            })
+          }
+          </div>
+        ))
+      }
     </div>
   );
 };

--- a/src/calendar/components/defaults/DefaultHeading.js
+++ b/src/calendar/components/defaults/DefaultHeading.js
@@ -2,13 +2,13 @@
 
 import React from 'react';
 
-type PagerProps = {
+type DefaultHeadingProps = {
   title: string,
   onNextMonthClicked: () => void,
   onPreviousMonthClicked: () => void,
 };
 
-export const Pager = (props: PagerProps) => {
+export const DefaultHeading = (props: DefaultHeadingProps) => {
   return (
     <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between', marginTop: 5, marginBottom: 5 }}>
       <button onClick={props.onPreviousMonthClicked}>{"<<<"}</button>

--- a/src/calendar/types.js
+++ b/src/calendar/types.js
@@ -1,0 +1,10 @@
+// @flow
+
+// There's no good way to create a type from 'weekdays' in flow, so redefine the list.
+// "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday";
+export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export type BorderOptions = {
+  color: string,
+  width: number,
+};

--- a/src/calendar/types.js
+++ b/src/calendar/types.js
@@ -1,7 +1,6 @@
 // @flow
 
-// There's no good way to create a type from 'weekdays' in flow, so redefine the list.
-// "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday";
+// These are the weekday integers, as defined in Javascript. 0 = Sunday, 6 = Saturday.
 export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
 export type BorderOptions = "no-border" | {

--- a/src/calendar/types.js
+++ b/src/calendar/types.js
@@ -4,7 +4,7 @@
 // "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday";
 export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export type BorderOptions = {
+export type BorderOptions = "no-border" | {
   color: string,
   width: number,
 };

--- a/src/calendar/util/__snapshots__/date.test.js.snap
+++ b/src/calendar/util/__snapshots__/date.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`calculates the number of weeks correctly with Monday start of week 1`] = `
+exports[`calendarWeeksInMonth calculates the number of weeks correctly with Monday start of week 1`] = `
 Array [
   Array [
     "2015-1 days: 5",
@@ -89,7 +89,7 @@ Array [
 ]
 `;
 
-exports[`calculates the number of weeks correctly with Sunday start of week 1`] = `
+exports[`calendarWeeksInMonth calculates the number of weeks correctly with Sunday start of week 1`] = `
 Array [
   Array [
     "2015-1 days: 5",

--- a/src/calendar/util/date.js
+++ b/src/calendar/util/date.js
@@ -1,17 +1,6 @@
 // @flow
 
 import type { Weekday } from '../types';
-
-// These are indexed the same as Date.prototype.getDay() indexes the days of the week.
-// const weekdays = [
-//   "Sunday",
-//   "Monday",
-//   "Tuesday",
-//   "Wednesday",
-//   "Thursday",
-//   "Friday",
-//   "Saturday",
-// ];
 type Week = [string, string, string, string, string, string, string];
 
 // Adapted from: https://stackoverflow.com/a/33451102/932896
@@ -37,8 +26,10 @@ function daysBetween(startDate: Date, endDate: Date): number {
 }
 
 export function localizedWeekdayNames(locale: string): Week {
-  // January 4th, 1970, 00:00:00. The first Sunday after the epoch.
+  // January 4th, 1970, 00:00:00. The first Sunday after the epoch. We can use any arbitrary Sunday, here, but we do 
+  // need concrete dates in order to get localized weekday names, using only native Javascript.
   const sunday = new Date(259200000);
+  // We (mostly) trust ourselves, so we type-cast the result of this to 'Week'.
   return ((Array(7).fill().map((_, i) => {
     const date = new Date(sunday.valueOf());
     date.setDate(date.getDate() + i);
@@ -47,7 +38,7 @@ export function localizedWeekdayNames(locale: string): Week {
 }
 
 /**
- * firstWeekDay The first week day based on Javascript's native getDay() method where Sun = 0 ... Sat = 6. eg. If you
+ * firstWeekDay - The first week day based on Javascript's native getDay() method where Sun = 0 ... Sat = 6. eg. If you
  *    want to indicate Mon, supply the value '1'.
  */
 export function weekOrderedByGivenFirstWeekday(locale: string, firstWeekDay: Weekday): Week {

--- a/src/calendar/util/date.js
+++ b/src/calendar/util/date.js
@@ -91,6 +91,11 @@ export function calendarWeeksInMonth(year: number, month: number, firstCalendarW
   return Math.ceil(daysInMonthExcludingFirstWeek / 7) + 1;
 }
 
+export function longMonthName(locale: string, year: number, month: number) {
+  const firstOfMonth = new Date(year, month-1, 1); // Convert from 1-indexed to 0-indexed.
+  return firstOfMonth.toLocaleDateString(locale, { month: "long", year: "numeric" })
+}
+
 export function nextMonth(year: number, month: number) {
   if (month === 12) {
     return {year: year + 1, month: 1};

--- a/src/calendar/util/date.test.js
+++ b/src/calendar/util/date.test.js
@@ -1,22 +1,75 @@
+// @flow
 
-import { calendarWeeksInMonth } from "./date";
+import { calendarWeeksInMonth, localizedWeekdayNames, weekOrderedByGivenFirstWeekday } from "./date";
 
-it('calculates the number of weeks correctly with Sunday start of week', () => {
-  const result = [2015, 2016, 2017, 2018, 2019, 2020].map(year =>
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(month =>
-      `${year}-${month} days: ${calendarWeeksInMonth(year, month, "Sunday")}`
+describe('calendarWeeksInMonth', () => {
+  it('calculates the number of weeks correctly with Sunday start of week', () => {
+    const result = [2015, 2016, 2017, 2018, 2019, 2020].map(year =>
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(month =>
+        `${year}-${month} days: ${calendarWeeksInMonth(year, month, 0)}`
+      )
     )
-  )
-  // Validated the snapshot results online against Google Calendar. Weeks/month match.
-  expect(result).toMatchSnapshot();
+    // Validated the snapshot results online against Google Calendar. Weeks/month match.
+    expect(result).toMatchSnapshot();
+  });
+
+  it('calculates the number of weeks correctly with Monday start of week', () => {
+    const result = [2015, 2016, 2017, 2018, 2019, 2020].map(year =>
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(month =>
+        `${year}-${month} days: ${calendarWeeksInMonth(year, month, 1)}`
+      )
+    )
+    // Validated the snapshot results online against timeanddate.com. Weeks/month match.
+    expect(result).toMatchSnapshot();
+  });
 });
 
-it('calculates the number of weeks correctly with Monday start of week', () => {
-  const result = [2015, 2016, 2017, 2018, 2019, 2020].map(year =>
-    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map(month =>
-      `${year}-${month} days: ${calendarWeeksInMonth(year, month, "Monday")}`
-    )
-  )
-  // Validated the snapshot results online against timeanddate.com. Weeks/month match.
-  expect(result).toMatchSnapshot();
+describe('weekOrderedByGivenFirstWeekday', () => {
+  it('orders correctly with Sunday first', () => {
+    expect(weekOrderedByGivenFirstWeekday('en-us', 0)).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+  });
+  it('orders correctly with Monday first', () => {
+    expect(weekOrderedByGivenFirstWeekday('en-us', 1)).toEqual([
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+    ]);
+  });
+  it ('orders correctly with Thursday first', () => {
+    expect(weekOrderedByGivenFirstWeekday('en-us', 4)).toEqual([
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+    ]);
+  });
+});
+
+describe('localizedWeekdayNames', () => {
+  it('works for long weekday descriptions in English', () => {
+      expect(localizedWeekdayNames('en-us')).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+  });
 });

--- a/src/examples/Example1.js
+++ b/src/examples/Example1.js
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
+import { DefaultHeading } from '../calendar/components/defaults/DefaultHeading';
+import { longMonthName, nextMonth, previousMonth } from '../calendar/util/date';
 
 type State = {
   year: number,
@@ -16,6 +18,8 @@ type Props = {};
  *  component's state.
  */
 export class Example1 extends Component<Props, State> {
+  locale = "en-us";
+
   constructor(props: Props) {
     super(props);
     const date = new Date();
@@ -32,7 +36,7 @@ export class Example1 extends Component<Props, State> {
 
   renderDay = (date: Date, cellID: string, selectedYear: number, selectedMonth: number) => {
     const dayNumber = date.getDate();
-    const dayText = dayNumber === 1 ? `${date.toLocaleDateString("en-us", {month: 'short'})} ${dayNumber}` : dayNumber;
+    const dayText = dayNumber === 1 ? `${date.toLocaleDateString(this.locale, {month: 'short'})} ${dayNumber}` : dayNumber;
     const selectedMonthStartDate = new Date(selectedYear, selectedMonth - 1, 1); // first day of month.
     const selectedMonthEndDate = new Date(selectedYear, selectedMonth, 0); // last day of month.
     const dayIsInSelectedMonth = date >= selectedMonthStartDate && date <= selectedMonthEndDate;
@@ -55,17 +59,32 @@ export class Example1 extends Component<Props, State> {
     );
   }
 
+  renderHeading = () => {
+    return (
+      <DefaultHeading
+        title={longMonthName(this.locale, this.state.year, this.state.month)}
+        onNextMonthClicked={() => {
+          const { year, month } = nextMonth(this.state.year, this.state.month);
+          this.setState({ year, month });
+        }}
+        onPreviousMonthClicked={() => {
+          const { year, month } = previousMonth(this.state.year, this.state.month);
+          this.setState({ year, month });
+        }}
+      />
+    );
+  };
+
   render() {
     return (
       <Calendar
-        locale="en-us"
+        locale={this.locale}
         year={this.state.year}
         month={this.state.month}
         renderDay={(date, cellID) => this.renderDay(date, cellID, this.state.year, this.state.month)}
+        renderHeading={this.renderHeading}
         borderOptions={{ width: 1, color: "black" }}
         onDayPress={this.onDayPress}
-        onNextMonthClicked={(year, month) => this.setState({ year, month })}
-        onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
       />
     );
   }

--- a/src/examples/Example1.js
+++ b/src/examples/Example1.js
@@ -1,0 +1,72 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import { Calendar } from '../calendar/Calendar';
+
+type State = {
+  year: number,
+  month: number,
+  selectedCellIDs: Array<string>
+};
+
+type Props = {};
+
+/** This example shows a calendar rendered in English with clickable days and paging implemented via the 
+ *  component's state.
+ */
+export class Example1 extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const date = new Date();
+    this.state = { year: date.getFullYear(), month: date.getMonth() + 1, selectedCellIDs: []};
+  }
+
+  onDayPress = (date: Date, cellID: string) => {
+    if (this.state.selectedCellIDs.indexOf(cellID) !== -1) {
+      this.setState({ selectedCellIDs: this.state.selectedCellIDs.filter(cID => cID !== cellID) });
+    } else {
+      this.setState({ selectedCellIDs: [...this.state.selectedCellIDs, cellID]});
+    }
+  }
+
+  renderDay = (date: Date, cellID: string, selectedYear: number, selectedMonth: number) => {
+    const dayNumber = date.getDate();
+    const dayText = dayNumber === 1 ? `${date.toLocaleDateString("en-us", {month: 'short'})} ${dayNumber}` : dayNumber;
+    const selectedMonthStartDate = new Date(selectedYear, selectedMonth - 1, 1); // first day of month.
+    const selectedMonthEndDate = new Date(selectedYear, selectedMonth, 0); // last day of month.
+    const dayIsInSelectedMonth = date >= selectedMonthStartDate && date <= selectedMonthEndDate;
+    const isToday = new Date().toDateString() === date.toDateString();
+    let color = `grey`;
+    let fontWeight = `normal`;
+    if (isToday) {
+      color = `blue`;
+      fontWeight = `bold`;
+    } else if (dayIsInSelectedMonth) {
+      color = `black`;
+    }
+    const backgroundColor = this.state.selectedCellIDs.indexOf(cellID) !== -1 ? `yellow` : `white`;
+    return (
+      <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart`, backgroundColor }} className="calendar-day">
+        <div style={{ display: 'flex', flex: 1, margin: 5, color, fontWeight }}>
+          {dayText}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Calendar
+        locale="en-us"
+        year={this.state.year}
+        month={this.state.month}
+        renderDay={(date, cellID) => this.renderDay(date, cellID, this.state.year, this.state.month)}
+        borderOptions={{ width: 1, color: "black" }}
+        onDayPress={this.onDayPress}
+        onNextMonthClicked={(year, month) => this.setState({ year, month })}
+        onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
+      />
+    );
+  }
+}

--- a/src/examples/Example2.js
+++ b/src/examples/Example2.js
@@ -3,6 +3,8 @@
 import React, { Component } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
+import { DefaultHeading } from '../calendar/components/defaults/DefaultHeading';
+import { longMonthName, nextMonth, previousMonth } from '../calendar/util/date';
 
 type State = {
   year: number,
@@ -13,11 +15,30 @@ type Props = {};
 
 /** This example shows a calendar rendered in English with paging implemented via the component's state. */
 export class Example2 extends Component<Props, State> {
+  locale = "fr-ca";
+
   constructor(props: Props) {
     super(props);
     const date = new Date();
     this.state = { year: date.getFullYear(), month: date.getMonth() + 1};
   }
+
+  renderHeading = () => {
+    return (
+      <DefaultHeading
+        title={longMonthName(this.locale, this.state.year, this.state.month)}
+        onNextMonthClicked={() => {
+          const { year, month } = nextMonth(this.state.year, this.state.month);
+          this.setState({ year, month });
+        }}
+        onPreviousMonthClicked={() => {
+          const { year, month } = previousMonth(this.state.year, this.state.month);
+          this.setState({ year, month });
+        }}
+      />
+    );
+  };
+
 
   renderDay = (date: Date) => {
     return (
@@ -32,10 +53,11 @@ export class Example2 extends Component<Props, State> {
   render() {
     return (
       <Calendar
-        locale="fr-ca"
+        locale={this.locale}
         year={this.state.year}
         month={this.state.month}
         renderDay={this.renderDay}
+        renderHeading={this.renderHeading}
         borderOptions={{ width: 2, color: "lightgrey" }}
         onNextMonthClicked={(year, month) => this.setState({ year, month })}
         onPreviousMonthClicked={(year, month) => this.setState({ year, month })}

--- a/src/examples/Example2.js
+++ b/src/examples/Example2.js
@@ -1,0 +1,45 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import { Calendar } from '../calendar/Calendar';
+
+type State = {
+  year: number,
+  month: number,
+};
+
+type Props = {};
+
+/** This example shows a calendar rendered in English with paging implemented via the component's state. */
+export class Example2 extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    const date = new Date();
+    this.state = { year: date.getFullYear(), month: date.getMonth() + 1};
+  }
+
+  renderDay = (date: Date) => {
+    return (
+      <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart` }} className="calendar-day">
+        <div style={{ display: 'flex', flex: 1, margin: 5 }}>
+          {date.getDate()}
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <Calendar
+        locale="en-us"
+        year={this.state.year}
+        month={this.state.month}
+        renderDay={this.renderDay}
+        borderOptions={{ width: 1, color: "black" }}
+        onNextMonthClicked={(year, month) => this.setState({ year, month })}
+        onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
+      />
+    );
+  }
+}

--- a/src/examples/Example2.js
+++ b/src/examples/Example2.js
@@ -59,8 +59,6 @@ export class Example2 extends Component<Props, State> {
         renderDay={this.renderDay}
         renderHeading={this.renderHeading}
         borderOptions={{ width: 2, color: "lightgrey" }}
-        onNextMonthClicked={(year, month) => this.setState({ year, month })}
-        onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
       />
     );
   }

--- a/src/examples/Example3.js
+++ b/src/examples/Example3.js
@@ -37,8 +37,6 @@ export class Example3 extends Component<Props, State> {
         month={this.state.month}
         renderDay={this.renderDay}
         borderOptions="no-border"
-        onNextMonthClicked={(year, month) => this.setState({ year, month })}
-        onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
       />
     );
   }

--- a/src/examples/Example3.js
+++ b/src/examples/Example3.js
@@ -12,7 +12,7 @@ type State = {
 type Props = {};
 
 /** This example shows a calendar rendered in English with paging implemented via the component's state. */
-export class Example2 extends Component<Props, State> {
+export class Example3 extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     const date = new Date();
@@ -32,11 +32,11 @@ export class Example2 extends Component<Props, State> {
   render() {
     return (
       <Calendar
-        locale="fr-ca"
+        locale="en-ca"
         year={this.state.year}
         month={this.state.month}
         renderDay={this.renderDay}
-        borderOptions={{ width: 2, color: "lightgrey" }}
+        borderOptions="no-border"
         onNextMonthClicked={(year, month) => this.setState({ year, month })}
         onPreviousMonthClicked={(year, month) => this.setState({ year, month })}
       />

--- a/src/examples/Example4.js
+++ b/src/examples/Example4.js
@@ -1,0 +1,62 @@
+// @flow
+
+import React, { Component } from 'react';
+
+import { Calendar } from '../calendar/Calendar';
+import { longMonthName, nextMonth } from '../calendar/util/date';
+
+
+type State = {
+  year: number,
+  month: number,
+};
+
+type Props = {};
+
+/** This example shows a calendar rendered in English with paging implemented via the component's state. */
+export class Example4 extends Component<Props, State> {
+  locale = "en-ca";
+
+  constructor(props: Props) {
+    super(props);
+    const date = new Date();
+    this.state = { year: date.getFullYear(), month: date.getMonth() + 1};
+  }
+
+  renderDay = (date: Date) => {
+    return (
+      <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart` }} className="calendar-day">
+        <div style={{ display: 'flex', flex: 1, margin: 5 }}>
+          {date.getDate()}
+        </div>
+      </div>
+    );
+  }
+
+  renderHeader = (year: number, month: number) => {
+    return <div>{longMonthName(this.locale, year, month)}</div>
+  }
+
+  render() {
+    const { year: secondMonthYear, month: secondMonth } = nextMonth(this.state.year, this.state.month)
+    return (
+      <div style={{ display: "flex", flexDirection: "row", height: 500, paddingTop: 40 }}>
+        <Calendar
+          locale={this.locale}
+          year={this.state.year}
+          month={this.state.month}
+          renderDay={this.renderDay}
+          renderHeading={() => this.renderHeader(this.state.year, this.state.month)}
+        />
+        <div style={{ width: 20 }} />
+        <Calendar
+          locale={this.locale}
+          year={secondMonthYear}
+          month={secondMonth}
+          renderDay={this.renderDay}
+          renderHeading={() => this.renderHeader(secondMonthYear, secondMonth)}
+        />
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
- The main "App" now provides a list of multiple examples that can be looked through.
- Created 3 more examples (on top of the existing 1 example) to demonstrate functionality.
- The month header / pagination area is now a renderProp and can be controlled by the calendar consumer.
- Extracted the old calendar header into an example / default component consumers can use if they want.