### PR TITLE
Weekday headings are now handled by a renderProp.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "simple-calendar",
   "version": "0.1.0",
+  "author": "Brennan Rauert <brennanrauert@gmail.com>",
   "private": true,
   "dependencies": {
     "react": "^16.4.2",

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -11,6 +11,7 @@ type CalendarProps = {|
   month: number,
   locale: string,
   renderDay: (date: Date, cellID: string) => Node,
+  renderDayHeading?: (dayIndex: number) => Node,
   renderHeading?: () => Node,
   borderOptions?: BorderOptions,
   // Since you can render the day as you please, onDayPress is a convenience method. You can implement your own 
@@ -26,7 +27,9 @@ export const Calendar = (props: CalendarProps) => {
         locale={props.locale}
         year={props.year}
         month={props.month}
+        firstWeekday={props.firstWeekday}
         renderDay={props.renderDay}
+        renderDayHeading={props.renderDayHeading}
         onDayPress={props.onDayPress}
         borderOptions={props.borderOptions}
       />

--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -3,21 +3,29 @@
 import React from 'react';
 import type { Node } from 'react';
 
-import { calendarWeeksInMonth, firstWeekdayInMonth, weekOrderedByGivenFirstWeekday } from "../util/date";
+import { arrayRotate } from "../util/array";
+import { calendarWeeksInMonth, firstWeekdayInMonth } from "../util/date";
 import "./Month.css";
 import type { BorderOptions, Weekday } from "../types";
 
-
-type MonthProps = {
+type MonthProps = {|
   locale: string,
   year: number,
+  firstWeekday?: Weekday,
   month: number,
   renderDay: (date: Date, cellID: string) => Node,
-  onDayPress?: (date: Date, cellID: string) => void,
+  renderDayHeading: ?(dayIndex: number) => Node,
+  onDayPress: ?(date: Date, cellID: string) => void,
   borderOptions?: BorderOptions,
+|};
+
+type WeekdayHeadingsProps = {
+  locale: string,
+  firstWeekday: Weekday,
+  renderDayHeading: (dayIndex: number) => Node,
 };
 
-const daysPerWeek = 7;
+const dayPerWeekRange = [0, 1, 2, 3, 4, 5, 6];
 const defaultBorderOptions: BorderOptions = {
   width: 1,
   color: "black",
@@ -53,12 +61,16 @@ const borderStyle = (dayIndex: number, weekIndex: number, lastWeekIndex: number,
   }
 }
 
-const Header = (props: { locale: string, firstWeekday: Weekday }) => {
+const WeekdayHeadings = (props: WeekdayHeadingsProps) => {
   return (
     <div className="Month-week-header">
-      {weekOrderedByGivenFirstWeekday(props.locale, props.firstWeekday).map(weekdayName =>
-        <div className="Month-week-header-weekday" key={weekdayName}>{weekdayName}</div>
-      )}
+      {
+        arrayRotate(dayPerWeekRange, props.firstWeekday).map(dayIndex => (
+          <div className="Month-week-header-weekday" key={dayIndex}>
+            {props.renderDayHeading && props.renderDayHeading(parseInt(dayIndex, 10))}
+          </div>
+        ))
+      }
     </div>
   );
 }
@@ -66,10 +78,13 @@ const Header = (props: { locale: string, firstWeekday: Weekday }) => {
 export const Month = (props: MonthProps) => {
   const weekdayOfTheFirst = firstWeekdayInMonth(props.year, props.month);
   const weekPerMonthRange = [...Array(calendarWeeksInMonth(props.year, props.month, 0)).keys()];
-  const dayPerWeekRange = [...Array(daysPerWeek).keys()];
   return (
     <div className="Month-month">
-      <Header firstWeekday={0} locale={props.locale} />
+      {
+        props.renderDayHeading && (
+          <WeekdayHeadings firstWeekday={0} locale={props.locale} renderDayHeading={props.renderDayHeading} />
+        )
+      }
       {
         weekPerMonthRange.map(weekOfMonthIndex => (
           <div key={weekOfMonthIndex} className="Month-week">

--- a/src/calendar/types.js
+++ b/src/calendar/types.js
@@ -2,6 +2,8 @@
 
 // These are the weekday integers, as defined in Javascript. 0 = Sunday, 6 = Saturday.
 export type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type WeekdayFormat = "narrow" | "short" | "long";
+export type Week = [string, string, string, string, string, string, string];
 
 export type BorderOptions = "no-border" | {
   color: string,

--- a/src/calendar/util/array.js
+++ b/src/calendar/util/array.js
@@ -1,0 +1,7 @@
+// @flow
+
+// Adapted from: https://stackoverflow.com/a/33451102/932896
+export function arrayRotate(arr: Array<any>, count: number) {
+  count -= arr.length * Math.floor(count / arr.length)
+  return  [...arr.slice(count), ...arr.splice(0, count)];
+}

--- a/src/calendar/util/date.js
+++ b/src/calendar/util/date.js
@@ -1,13 +1,6 @@
 // @flow
 
 import type { Weekday } from '../types';
-type Week = [string, string, string, string, string, string, string];
-
-// Adapted from: https://stackoverflow.com/a/33451102/932896
-function arrayRotate(arr, count) {
-  count -= arr.length * Math.floor(count / arr.length)
-  return  [...arr.slice(count), ...arr.splice(0, count)];
-}
 
 // https://stackoverflow.com/a/11252167/932896
 function treatAsUTC(date: Date): Date {
@@ -23,29 +16,6 @@ function treatAsUTC(date: Date): Date {
 function daysBetween(startDate: Date, endDate: Date): number {
   const millisecondsPerDay = 24 * 60 * 60 * 1000;
   return (treatAsUTC(endDate) - treatAsUTC(startDate)) / millisecondsPerDay;
-}
-
-export function localizedWeekdayNames(locale: string): Week {
-  // January 4th, 1970, 00:00:00. The first Sunday after the epoch. We can use any arbitrary Sunday, here, but we do 
-  // need concrete dates in order to get localized weekday names, using only native Javascript.
-  const sunday = new Date(259200000);
-  // We (mostly) trust ourselves, so we type-cast the result of this to 'Week'.
-  return ((Array(7).fill().map((_, i) => {
-    const date = new Date(sunday.valueOf());
-    date.setDate(date.getDate() + i);
-    return date.toLocaleDateString(locale, {weekday: 'long', timeZone: "utc"});
-  }): any): Week);
-}
-
-/**
- * firstWeekDay - The first week day based on Javascript's native getDay() method where Sun = 0 ... Sat = 6. eg. If you
- *    want to indicate Mon, supply the value '1'.
- */
-export function weekOrderedByGivenFirstWeekday(locale: string, firstWeekDay: Weekday): Week {
-  // We know we'll get a list of 7 weekdays out of this, but flow does not support a type for a tuple with a 
-  // generic amount of parameters, so we can't type arrayRotate as [genericNumberOfParams] => [genericNumberOfParams].
-  // As such, we're helping flow out by telling it we know we have a 'Week' to return, here.
-  return ((arrayRotate([...localizedWeekdayNames(locale)], firstWeekDay): any): Week);
 }
 
 export function daysInFirstCalendarWeek(firstDayOfTheMonth: Date, firstCalendarWeekday: Weekday): number {
@@ -80,11 +50,6 @@ export function calendarWeeksInMonth(year: number, month: number, firstCalendarW
   // we need to include an additional calendar week for partial weeks, 'ceil' the division result. Add 1 to account
   // for the first week of the month.
   return Math.ceil(daysInMonthExcludingFirstWeek / 7) + 1;
-}
-
-export function longMonthName(locale: string, year: number, month: number) {
-  const firstOfMonth = new Date(year, month-1, 1); // Convert from 1-indexed to 0-indexed.
-  return firstOfMonth.toLocaleDateString(locale, { month: "long", year: "numeric" })
 }
 
 export function nextMonth(year: number, month: number) {

--- a/src/calendar/util/date.test.js
+++ b/src/calendar/util/date.test.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { calendarWeeksInMonth, localizedWeekdayNames, weekOrderedByGivenFirstWeekday } from "./date";
+import { calendarWeeksInMonth } from "./date";
 
 describe('calendarWeeksInMonth', () => {
   it('calculates the number of weeks correctly with Sunday start of week', () => {
@@ -21,55 +21,5 @@ describe('calendarWeeksInMonth', () => {
     )
     // Validated the snapshot results online against timeanddate.com. Weeks/month match.
     expect(result).toMatchSnapshot();
-  });
-});
-
-describe('weekOrderedByGivenFirstWeekday', () => {
-  it('orders correctly with Sunday first', () => {
-    expect(weekOrderedByGivenFirstWeekday('en-us', 0)).toEqual([
-      'Sunday',
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-    ]);
-  });
-  it('orders correctly with Monday first', () => {
-    expect(weekOrderedByGivenFirstWeekday('en-us', 1)).toEqual([
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-      'Sunday',
-    ]);
-  });
-  it ('orders correctly with Thursday first', () => {
-    expect(weekOrderedByGivenFirstWeekday('en-us', 4)).toEqual([
-      'Thursday',
-      'Friday',
-      'Saturday',
-      'Sunday',
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-    ]);
-  });
-});
-
-describe('localizedWeekdayNames', () => {
-  it('works for long weekday descriptions in English', () => {
-      expect(localizedWeekdayNames('en-us')).toEqual([
-      'Sunday',
-      'Monday',
-      'Tuesday',
-      'Wednesday',
-      'Thursday',
-      'Friday',
-      'Saturday',
-    ]);
   });
 });

--- a/src/calendar/util/localizeDate.js
+++ b/src/calendar/util/localizeDate.js
@@ -1,0 +1,46 @@
+// @flow
+
+import { arrayRotate } from './array.js';
+import type { Week, Weekday } from '../types';
+
+export type YearFormat = "numeric" | "2-digit";
+export type MonthFormat = "numeric" | "2-digit" | "narrow" | "short" | "long";
+export type WeekdayFormat = "narrow" | "short" | "long";
+
+export function localizedYearMonth(
+  locale: string,
+  monthFormat: MonthFormat,
+  yearFormat: YearFormat,
+  year: number,
+  month: number
+) {
+  const firstOfMonth = new Date(year, month-1, 1); // Convert from 1-indexed to 0-indexed.
+  return firstOfMonth.toLocaleDateString(locale, { month: monthFormat, year: yearFormat })
+}
+
+export function localizedWeekdayNames(locale: string, format: WeekdayFormat): Week {
+  // January 4th, 1970, 00:00:00. The first Sunday after the epoch. We can use any arbitrary Sunday, here, but we do 
+  // need concrete dates in order to get localized weekday names, using only native Javascript.
+  const sunday = new Date(259200000);
+  // We (mostly) trust ourselves, so we type-cast the result of this to 'Week'.
+  return ((Array(7).fill().map((_, i) => {
+    const date = new Date(sunday.valueOf());
+    date.setDate(date.getDate() + i);
+    return date.toLocaleDateString(locale, {weekday: format, timeZone: "utc"});
+  }): any): Week);
+}
+
+/**
+ * firstWeekDay - The first week day based on Javascript's native getDay() method where Sun = 0 ... Sat = 6. eg. If you
+ *    want to indicate Mon, supply the value '1'.
+ */
+export function localizedWeekdayNamesStartingWith(
+  locale: string,
+  format: WeekdayFormat,
+  startingWeekDay: Weekday
+): Week {
+  // We know we'll get a list of 7 weekdays out of this, but flow does not support a type for a tuple with a 
+  // generic amount of parameters, so we can't type arrayRotate as [genericNumberOfParams] => [genericNumberOfParams].
+  // As such, we're helping flow out by telling it we know we have a 'Week' to return, here.
+  return ((arrayRotate([...localizedWeekdayNames(locale, format)], startingWeekDay): any): Week);
+}

--- a/src/calendar/util/localizedDate.test.js
+++ b/src/calendar/util/localizedDate.test.js
@@ -1,0 +1,54 @@
+// @flow
+
+import { localizedWeekdayNames, localizedWeekdayNamesStartingWith } from "./localizeDate";
+
+describe('localizedWeekdayNames', () => {
+  it('works for long weekday descriptions in English', () => {
+    expect(localizedWeekdayNames('en-us', 'long')).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+  });
+});
+
+
+describe('localizedWeekdayNamesStartingWith', () => {
+  it('orders correctly with Sunday first', () => {
+    expect(localizedWeekdayNamesStartingWith('en-us', 'long', 0)).toEqual([
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+    ]);
+  });
+  it('orders correctly with Monday first', () => {
+    expect(localizedWeekdayNamesStartingWith('en-us', 'long', 1)).toEqual([
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+    ]);
+  });
+  it ('orders correctly with Thursday first', () => {
+    expect(localizedWeekdayNamesStartingWith('en-us', 'long', 4)).toEqual([
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+    ]);
+  });
+});

--- a/src/examples/Example1.js
+++ b/src/examples/Example1.js
@@ -1,10 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
+import type { Element } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
 import { DefaultHeading } from '../calendar/components/defaults/DefaultHeading';
-import { longMonthName, nextMonth, previousMonth } from '../calendar/util/date';
+import { nextMonth, previousMonth } from '../calendar/util/date';
+import { localizedWeekdayNames, localizedYearMonth } from '../calendar/util/localizeDate';
 
 type State = {
   year: number,
@@ -19,6 +21,7 @@ type Props = {};
  */
 export class Example1 extends Component<Props, State> {
   locale = "en-us";
+  localizedWeekdayNames = localizedWeekdayNames(this.locale, "long");
 
   constructor(props: Props) {
     super(props);
@@ -51,7 +54,17 @@ export class Example1 extends Component<Props, State> {
     }
     const backgroundColor = this.state.selectedCellIDs.indexOf(cellID) !== -1 ? `yellow` : `white`;
     return (
-      <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart`, backgroundColor }} className="calendar-day">
+      <div
+        style={{
+          display: "flex",
+          flex: 1,
+          justifyContent: "flexStart",
+          cursor: "pointer",
+          userSelect: "none",
+          backgroundColor 
+        }} 
+        className="calendar-day"
+      >
         <div style={{ display: 'flex', flex: 1, margin: 5, color, fontWeight }}>
           {dayText}
         </div>
@@ -59,10 +72,14 @@ export class Example1 extends Component<Props, State> {
     );
   }
 
+  renderDayHeading = (dayIndex: number): Element<*> => (
+    <div>{this.localizedWeekdayNames[dayIndex]}</div>
+  );
+
   renderHeading = () => {
     return (
       <DefaultHeading
-        title={longMonthName(this.locale, this.state.year, this.state.month)}
+        title={localizedYearMonth(this.locale, "long", "numeric", this.state.year, this.state.month)}
         onNextMonthClicked={() => {
           const { year, month } = nextMonth(this.state.year, this.state.month);
           this.setState({ year, month });
@@ -82,6 +99,7 @@ export class Example1 extends Component<Props, State> {
         year={this.state.year}
         month={this.state.month}
         renderDay={(date, cellID) => this.renderDay(date, cellID, this.state.year, this.state.month)}
+        renderDayHeading={this.renderDayHeading}
         renderHeading={this.renderHeading}
         borderOptions={{ width: 1, color: "black" }}
         onDayPress={this.onDayPress}

--- a/src/examples/Example2.js
+++ b/src/examples/Example2.js
@@ -1,10 +1,12 @@
 // @flow
 
 import React, { Component } from 'react';
+import type { Node } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
 import { DefaultHeading } from '../calendar/components/defaults/DefaultHeading';
-import { longMonthName, nextMonth, previousMonth } from '../calendar/util/date';
+import { nextMonth, previousMonth } from '../calendar/util/date';
+import { localizedWeekdayNames, localizedYearMonth } from '../calendar/util/localizeDate';
 
 type State = {
   year: number,
@@ -16,6 +18,7 @@ type Props = {};
 /** This example shows a calendar rendered in English with paging implemented via the component's state. */
 export class Example2 extends Component<Props, State> {
   locale = "fr-ca";
+  localizedWeekdayNames = localizedWeekdayNames(this.locale, "short");
 
   constructor(props: Props) {
     super(props);
@@ -26,7 +29,7 @@ export class Example2 extends Component<Props, State> {
   renderHeading = () => {
     return (
       <DefaultHeading
-        title={longMonthName(this.locale, this.state.year, this.state.month)}
+        title={localizedYearMonth(this.locale, "long", "numeric", this.state.year, this.state.month)}
         onNextMonthClicked={() => {
           const { year, month } = nextMonth(this.state.year, this.state.month);
           this.setState({ year, month });
@@ -39,6 +42,9 @@ export class Example2 extends Component<Props, State> {
     );
   };
 
+  renderDayHeading = (dayIndex: number): Node => (
+    <div>{this.localizedWeekdayNames[dayIndex]}</div>
+  );
 
   renderDay = (date: Date) => {
     return (
@@ -57,6 +63,7 @@ export class Example2 extends Component<Props, State> {
         year={this.state.year}
         month={this.state.month}
         renderDay={this.renderDay}
+        renderDayHeading={this.renderDayHeading}
         renderHeading={this.renderHeading}
         borderOptions={{ width: 2, color: "lightgrey" }}
       />

--- a/src/examples/Example3.js
+++ b/src/examples/Example3.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
+import type { Node } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
 
@@ -19,7 +20,7 @@ export class Example3 extends Component<Props, State> {
     this.state = { year: date.getFullYear(), month: date.getMonth() + 1};
   }
 
-  renderDay = (date: Date) => {
+  renderDay = (date: Date): Node => {
     return (
       <div style={{ display: 'flex', flex: 1, justifyContent: `flexStart` }} className="calendar-day">
         <div style={{ display: 'flex', flex: 1, margin: 5 }}>

--- a/src/examples/Example4.js
+++ b/src/examples/Example4.js
@@ -1,9 +1,11 @@
 // @flow
 
 import React, { Component } from 'react';
+import type { Node } from 'react';
 
 import { Calendar } from '../calendar/Calendar';
-import { longMonthName, nextMonth } from '../calendar/util/date';
+import { nextMonth } from '../calendar/util/date';
+import { localizedWeekdayNames, localizedYearMonth } from '../calendar/util/localizeDate';
 
 
 type State = {
@@ -16,6 +18,7 @@ type Props = {};
 /** This example shows a calendar rendered in English with paging implemented via the component's state. */
 export class Example4 extends Component<Props, State> {
   locale = "en-ca";
+  localizedWeekdayNames = localizedWeekdayNames(this.locale, "narrow");
 
   constructor(props: Props) {
     super(props);
@@ -33,20 +36,35 @@ export class Example4 extends Component<Props, State> {
     );
   }
 
-  renderHeader = (year: number, month: number) => {
-    return <div>{longMonthName(this.locale, year, month)}</div>
-  }
+  renderHeading = (year: number, month: number): Node => (
+    <div style={{ fontSize: 22 }}>{localizedYearMonth(this.locale, "long", "numeric", year, month)}</div>
+  );
+
+  renderDayHeading = (dayIndex: number): Node => (
+    <div>{this.localizedWeekdayNames[dayIndex]}</div>
+  );
 
   render() {
     const { year: secondMonthYear, month: secondMonth } = nextMonth(this.state.year, this.state.month)
     return (
-      <div style={{ display: "flex", flexDirection: "row", height: 500, paddingTop: 40 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          flex: 1,
+          height: 500,
+          paddingTop: 40,
+          paddingLeft: 20,
+          paddingRight: 20,
+        }}
+      >
         <Calendar
           locale={this.locale}
           year={this.state.year}
           month={this.state.month}
           renderDay={this.renderDay}
-          renderHeading={() => this.renderHeader(this.state.year, this.state.month)}
+          renderDayHeading={this.renderDayHeading}
+          renderHeading={() => this.renderHeading(this.state.year, this.state.month)}
         />
         <div style={{ width: 20 }} />
         <Calendar
@@ -54,7 +72,8 @@ export class Example4 extends Component<Props, State> {
           year={secondMonthYear}
           month={secondMonth}
           renderDay={this.renderDay}
-          renderHeading={() => this.renderHeader(secondMonthYear, secondMonth)}
+          renderDayHeading={this.renderDayHeading}
+          renderHeading={() => this.renderHeading(secondMonthYear, secondMonth)}
         />
       </div>
     );


### PR DESCRIPTION
- some code restructuring, particularly with the utility classes
  - I'm preparing for a world in which the localization can be handled by external source, like `moment.js` (or whatever other date library this libraries consumers may want to use)
